### PR TITLE
remove mtls support

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"strings"
 	"time"
 
 	"gopkg.in/yaml.v3"
@@ -23,17 +22,16 @@ type LogOptions struct {
 }
 
 type Config struct {
-	Proxy             string
-	RunWaitTime       time.Duration
-	Inbounds          []ProcessConfig
-	Outbounds         []ProcessConfig
-	Log               LogOptions
-	Url               string
-	Username          string
-	Password          string
-	CAFile            string `mapstructure:"cafile"`
-	ClientCertificate string `mapstructure:"clientcert"`
-	ServiceName       string
+	Proxy       string
+	RunWaitTime time.Duration
+	Inbounds    []ProcessConfig
+	Outbounds   []ProcessConfig
+	Log         LogOptions
+	Url         string
+	Username    string
+	Password    string
+	CAFile      string `mapstructure:"cafile"`
+	ServiceName string
 }
 
 func ReadConfig(configFile string) (Config, string, error) {
@@ -77,17 +75,6 @@ func ReadConfig(configFile string) (Config, string, error) {
 
 	if err := yaml.NewDecoder(file).Decode(&cfg); err != nil {
 		return Config{}, "", fmt.Errorf("failed to decode configuration file: %w", err)
-	}
-
-	if strings.HasPrefix(cfg.ClientCertificate, "./") {
-		cfg.ClientCertificate = filepath.Join(filepath.Dir(configFile), cfg.ClientCertificate)
-	}
-
-	if cfg.ClientCertificate == "" {
-		clientcert := filepath.Join(filepath.Dir(configFile), "client.crt")
-		if _, err := os.Stat(clientcert); err == nil {
-			cfg.ClientCertificate = clientcert
-		}
 	}
 
 	return cfg, configFile, nil

--- a/connector/connector.go
+++ b/connector/connector.go
@@ -34,7 +34,7 @@ type Connector struct {
 
 // New creates client with given options
 func New(logger *slog.Logger, cfg config.Config) (*Connector, error) {
-	platformClient, err := platform.NewClient(cfg.Url, cfg.Username, cfg.Password, cfg.ClientCertificate, cfg.CAFile, cfg.Proxy)
+	platformClient, err := platform.NewClient(cfg.Url, cfg.Username, cfg.Password, cfg.CAFile, cfg.Proxy)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create platform client: %w", err)
 	}

--- a/platform/client.go
+++ b/platform/client.go
@@ -37,7 +37,7 @@ type Client struct {
 	baseUrl string
 }
 
-func NewClient(baseUrl string, username string, password string, certFile string, caFile string, proxy string) (*Client, error) {
+func NewClient(baseUrl string, username string, password string, caFile string, proxy string) (*Client, error) {
 	httpTransport := http.DefaultTransport
 	if proxy != "" {
 		url, err := url.Parse(proxy)
@@ -50,18 +50,6 @@ func NewClient(baseUrl string, username string, password string, certFile string
 	if tlsConfig == nil {
 		tlsConfig = &tls.Config{}
 		httpTransport.(*http.Transport).TLSClientConfig = tlsConfig
-	}
-
-	if certFile != "" {
-		if _, err := os.Stat(certFile); !os.IsNotExist(err) {
-			return nil, fmt.Errorf("client certFileificate %s does not exist", certFile)
-		}
-		certFile, err := tls.LoadX509KeyPair(certFile, certFile)
-		if err != nil {
-			return nil, fmt.Errorf("error loading client certFileificate: %w", err)
-		}
-
-		tlsConfig.Certificates = []tls.Certificate{certFile}
 	}
 
 	httpClient := &http.Client{

--- a/platform/client_test.go
+++ b/platform/client_test.go
@@ -41,7 +41,7 @@ func TestUsernamePassword(t *testing.T) {
 	}))
 	defer server.Close()
 
-	cl, err := platform.NewClient(server.URL, testUsername, testPassword, "", "", "")
+	cl, err := platform.NewClient(server.URL, testUsername, testPassword, "", "")
 	if err != nil {
 		t.Errorf("failed to create edi client: %v", err)
 	}
@@ -77,7 +77,7 @@ func TestUserAgent(t *testing.T) {
 	}))
 	defer server.Close()
 
-	cl, err := platform.NewClient(server.URL, testUsername, testPassword, "", "", "")
+	cl, err := platform.NewClient(server.URL, testUsername, testPassword, "", "")
 	if err != nil {
 		t.Errorf("failed to create edi client: %v", err)
 	}
@@ -100,7 +100,7 @@ func TestAccept(t *testing.T) {
 	}))
 	defer server.Close()
 
-	cl, err := platform.NewClient(server.URL, "", "", "", "", "")
+	cl, err := platform.NewClient(server.URL, "", "", "", "")
 	if err != nil {
 		t.Errorf("failed to create edi client: %v", err)
 	}
@@ -118,7 +118,7 @@ func TestDownloadTransmission(t *testing.T) {
 	}))
 	defer server.Close()
 
-	cl, err := platform.NewClient("", "", "", "", "", "")
+	cl, err := platform.NewClient("", "", "", "", "")
 	if err != nil {
 		t.Errorf("failed to create edi client: %v", err)
 	}
@@ -158,7 +158,7 @@ func TestListTransmissions(t *testing.T) {
 	}))
 	defer server.Close()
 
-	cl, err := platform.NewClient(server.URL, "", "", "", "", "")
+	cl, err := platform.NewClient(server.URL, "", "", "", "")
 	if err != nil {
 		t.Errorf("failed to create edi client: %v", err)
 	}
@@ -212,7 +212,7 @@ func TestAddTransmission(t *testing.T) {
 	}))
 	defer server.Close()
 
-	cl, err := platform.NewClient(server.URL, "", "", "", "", "")
+	cl, err := platform.NewClient(server.URL, "", "", "", "")
 	if err != nil {
 		t.Errorf("failed to create edi client: %v", err)
 	}
@@ -225,7 +225,7 @@ func TestAddTransmission(t *testing.T) {
 
 func TestConfirmTransmission(t *testing.T) {
 	transmissionId := "123515"
-	testData := []byte(fmt.Sprintf(`{"error":false,"message":"processed transmission %s"}`, transmissionId))
+	testData := fmt.Appendf([]byte{}, `{"error":false,"message":"processed transmission %s"}`, transmissionId)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		expectedPath := fmt.Sprintf("/rest/v2/transmissions/%s/confirm", transmissionId)
 		gotPath := r.URL.Path
@@ -251,7 +251,7 @@ func TestConfirmTransmission(t *testing.T) {
 	}))
 	defer server.Close()
 
-	cl, err := platform.NewClient(server.URL, "", "", "", "", "")
+	cl, err := platform.NewClient(server.URL, "", "", "", "")
 	if err != nil {
 		t.Errorf("failed to create edi client: %v", err)
 	}
@@ -310,7 +310,7 @@ func TestAddAttachment(t *testing.T) {
 	}))
 	defer server.Close()
 
-	cl, err := platform.NewClient(server.URL, "", "", "", "", "")
+	cl, err := platform.NewClient(server.URL, "", "", "", "")
 	if err != nil {
 		t.Errorf("failed to create edi client: %v", err)
 	}
@@ -343,7 +343,7 @@ func TestListMessageAttachments(t *testing.T) {
 	}))
 	defer server.Close()
 
-	cl, err := platform.NewClient(server.URL, "", "", "", "", "")
+	cl, err := platform.NewClient(server.URL, "", "", "", "")
 	if err != nil {
 		t.Errorf("failed to create edi client: %v", err)
 	}


### PR DESCRIPTION
Drop support for mTLS connections onto the platform. This is no longer supported within the new api endpoints.