### PR TITLE
feat: add file to confirmation message

### DIFF
--- a/connector/connector.go
+++ b/connector/connector.go
@@ -190,7 +190,7 @@ func (c *Connector) inboundMessages(ctx context.Context, inbound transport.Inbou
 
 		ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
 		defer cancel()
-		err = inbound.ProcessMessage(ctx, transport.Object{
+		statusMsg, err := inbound.ProcessMessage(ctx, transport.Object{
 			Id:       transmission.Id,
 			Content:  data,
 			Metadata: transmission.Metadata,
@@ -202,7 +202,7 @@ func (c *Connector) inboundMessages(ctx context.Context, inbound transport.Inbou
 
 		ctx, cancel = context.WithTimeout(ctx, 15*time.Second)
 		defer cancel()
-		err = c.platformClient.ConfirmTransmission(ctx, transmission.Id)
+		err = c.platformClient.ConfirmTransmission(ctx, transmission.Id, statusMsg)
 		if err != nil {
 			return fmt.Errorf("could not confirm inbound transmission %s: %w", transmission.Id, err)
 		}

--- a/platform/client.go
+++ b/platform/client.go
@@ -156,12 +156,12 @@ func (c *Client) AddTransmission(ctx context.Context, configId string, data []by
 	return nil
 }
 
-func (c *Client) ConfirmTransmission(ctx context.Context, id string) error {
+func (c *Client) ConfirmTransmission(ctx context.Context, id, status string) error {
 	var confirmRequest struct {
 		Error   bool   `json:"error"`
 		Message string `json:"message"`
 	}
-	confirmRequest.Message = fmt.Sprintf("processed transmission %s", id)
+	confirmRequest.Message = status
 
 	data, err := json.Marshal(confirmRequest)
 	if err != nil {

--- a/platform/client_test.go
+++ b/platform/client_test.go
@@ -225,7 +225,7 @@ func TestAddTransmission(t *testing.T) {
 
 func TestConfirmTransmission(t *testing.T) {
 	transmissionId := "123515"
-	testData := fmt.Appendf([]byte{}, `{"error":false,"message":"processed transmission %s"}`, transmissionId)
+	testData := fmt.Appendf([]byte{}, `{"error":false,"message":"Creaded file: test.txt"}`)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		expectedPath := fmt.Sprintf("/v2/transmissions/%s/confirm", transmissionId)
 		gotPath := r.URL.Path
@@ -256,7 +256,7 @@ func TestConfirmTransmission(t *testing.T) {
 		t.Errorf("failed to create edi client: %v", err)
 	}
 
-	err = cl.ConfirmTransmission(t.Context(), transmissionId)
+	err = cl.ConfirmTransmission(t.Context(), transmissionId, "Creaded file: test.txt")
 	if err != nil {
 		t.Errorf("failed to confirm transmission: %v", err)
 	}

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -20,7 +20,7 @@ type OutboundTransport interface {
 }
 
 type InboundTransport interface {
-	ProcessMessage(context.Context, Object) error
+	ProcessMessage(context.Context, Object) (string, error)
 	ProcessAttachment(context.Context, Object) error
 	// Return if attachment should be processed by specific processor
 	HandleAttachment(url string) bool


### PR DESCRIPTION
This CL updates the confirmation message to include the file name, enabling the support team to provide customers with the exact filename for a transmission.